### PR TITLE
SAK-43079 - All of the Help Tool's htm files have the same <title> tag

### DIFF
--- a/sakai-help-parse.php
+++ b/sakai-help-parse.php
@@ -151,7 +151,9 @@ foreach ($manuals->site->manuals AS $manual) {
       $article_header = '<div id="article-header"><h1 class="article-title">' . $a->article->title . '</h1></div>';
       $article_html = Htmlawed::filter('<div id="wrapper"><div id="article-content">' . $article_header . 
         '<div id="article-description">' . $article_text . '</div></div></div>', ['unique_ids' => 1] );
-      $article_html = str_replace('ARTICLE-TEXT', $article_html, file_get_contents('sakai-help-stub.html'));
+      $article_html = str_replace('{{ARTICLE-TEXT}}', $article_html, file_get_contents('sakai-help-stub.html'));
+      $article_html = str_replace('{{ARTICLE-DESCRIPTION}}', $default_for_chapter, $article_html);
+      $article_html = str_replace('{{ARTICLE-TITLE}}', $a->article->title, $article_html);
       $article_html = clean_html ($article_html);
       $ret = file_put_contents($svnpath . $destpath . $article_file, $article_html);
       if (!$ret) print "ERROR: problem copying $article_id to $svnpath$destpath$article_file \n";

--- a/sakai-help-stub.html
+++ b/sakai-help-stub.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>How do I enable student peer review for an assignment?</title>
+<title>{{ARTICLE-TITLE}}</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta content="sakai.assignment" name="description">
-<meta content="peer review, peer assessment, peer evaluation" name="search">
+<meta content="{{ARTICLE-DESCRIPTION}}" name="description">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="../css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
@@ -21,6 +20,6 @@
 </script>
 </head>
 <body>
-  ARTICLE-TEXT
+  {{ARTICLE-TEXT}}
 </body>
 </html>


### PR DESCRIPTION
- Fixed filling in title for title tag
- Removed the meta search as it didn't seem to be needed and wasn't sure what terms to use without defining a new method to look up the terms for the tool id. The other 2 values looked to be filled in. 
- Changed the variables to mustache style so they won't cause any possible replacement problems.